### PR TITLE
fix: first wallet init does not work

### DIFF
--- a/src/useFunDemo.js
+++ b/src/useFunDemo.js
@@ -6,7 +6,6 @@ import {
   configureNewFunStore,
   MetamaskConnector,
   Goerli,
-  usePrimaryAuth,
 } from "@funkit/react";
 import { useState, useCallback } from "react";
 import { Token } from "@funkit/core";

--- a/src/useFunDemo.js
+++ b/src/useFunDemo.js
@@ -6,6 +6,7 @@ import {
   configureNewFunStore,
   MetamaskConnector,
   Goerli,
+  usePrimaryAuth,
 } from "@funkit/react";
 import { useState, useCallback } from "react";
 import { Token } from "@funkit/core";
@@ -37,7 +38,7 @@ const useFunDemo = () => {
     deactivate,
     connector,
     account: connectorAccount,
-  } = useConnector({ index: 0 });
+  } = useConnector({ index: 0, autoConnect: true });
 
   const toggleConnect = useCallback(async () => {
     if (connectionIsActive) {


### PR DESCRIPTION
## Description

Fixes: [FRO-284](https://linear.app/funxyz/issue/FRO-284/sample-app-onofframp-web-demo-bug)

**Before**

First wallet initialization (with fresh mm account) always throws error in codesandbox.

<img width="1297" alt="Screenshot 2023-10-19 at 3 38 57 AM" src="https://github.com/fun-xyz/Onofframp-Web-Demo/assets/95644202/43385d83-0fd6-4a5f-be86-a845f963810d">

---

**After**

Setting `autoConnect: true` fixes this. Alternatively, call `activate()`.

https://github.com/fun-xyz/Onofframp-Web-Demo/assets/95644202/d491f56c-639e-4692-8f72-5ab933ee0b33

